### PR TITLE
Remove code coverage from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,39 +122,3 @@ jobs:
       with:
         name: static-analysis-results
         path: build
-
-  code-coverage:
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
-      with:
-        submodules: true
-
-    - name: Update submodules
-      run: git submodule update --init --recursive
-
-    - name: Set up SDL
-      uses: libsdl-org/setup-sdl@main
-
-    - name: Set up llvm-cov
-      run: sudo apt-get install -y llvm
-
-    - name: Configure CMake with code coverage
-      run: cmake -B build -S . -DENABLE_COVERAGE=ON
-
-    - name: Build with code coverage
-      run: cmake --build build
-
-    - name: Run tests
-      run: ctest --output-on-failure
-
-    - name: Generate coverage report
-      run: llvm-cov gcov -o . build/*.o
-
-    - name: Upload coverage report
-      uses: actions/upload-artifact@v4
-      with:
-        name: coverage-report
-        path: coverage.info

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,17 +27,8 @@ set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
 # Include cxxopts headers
 include_directories(external/cxxopts/include)
 
-# Add ENABLE_COVERAGE option
-option(ENABLE_COVERAGE "Enable code coverage" OFF)
-
 # Add ENABLE_CLANG_TIDY option
 option(ENABLE_CLANG_TIDY "Enable clang-tidy" OFF)
-
-# Add coverage flags to compiler options when ENABLE_COVERAGE is enabled
-if(ENABLE_COVERAGE)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
-endif()
 
 # Add clang-tidy to CMake configuration when ENABLE_CLANG_TIDY is enabled
 if(ENABLE_CLANG_TIDY)


### PR DESCRIPTION
Fixes #15

Remove code coverage from CI.

* Remove the `code-coverage` job from the `.github/workflows/ci.yml` file.
* Remove the `ENABLE_COVERAGE` option and related flags from the `CMakeLists.txt` file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mpiispanen/platformer_prototype/issues/15?shareId=9fa41c23-6a86-43d3-95ad-3af53a0a4884).