### PR TITLE
Add basic unit tests using google test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
     - name: Build
       run: cmake --build build
 
+    - name: Run tests
+      run: ctest --output-on-failure
+
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4
       with:
@@ -56,6 +59,9 @@ jobs:
 
     - name: Build
       run: cmake --build build
+
+    - name: Run tests
+      run: ctest --output-on-failure
 
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,8 +65,11 @@ add_executable(runTests tests/test_main.cpp)
 # Link Google Test libraries
 target_link_libraries(runTests gtest gtest_main)
 
-# Add test target
-add_test(NAME runTests COMMAND runTests)
+# Include GoogleTest module
+include(GoogleTest)
+
+# Automatically discover and register tests
+gtest_discover_tests(runTests)
 
 # Add gtest_force_shared_crt setting
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,6 @@ set(CMAKE_BUILD_TYPE Debug CACHE STRING "Choose the type of build (Debug or Rele
 set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release")
 
 # Add compiler flags for debug and release builds
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
 
 # Include cxxopts headers

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,3 +53,18 @@ if(ENABLE_CLANG_TIDY)
     COMMENT "Running clang-tidy"
   )
 endif()
+
+# Add Google Test submodule
+add_subdirectory(external/googletest)
+
+# Enable testing
+enable_testing()
+
+# Add test executable
+add_executable(runTests tests/test_main.cpp)
+
+# Link Google Test libraries
+target_link_libraries(runTests gtest gtest_main)
+
+# Add test target
+add_test(NAME runTests COMMAND runTests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,3 +67,6 @@ target_link_libraries(runTests gtest gtest_main)
 
 # Add test target
 add_test(NAME runTests COMMAND runTests)
+
+# Add gtest_force_shared_crt setting
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -1,0 +1,10 @@
+#include <gtest/gtest.h>
+
+TEST(SampleTest, AssertionTrue) {
+    ASSERT_TRUE(true);
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Fixes #19

Add basic unit tests using Google Test to the project.

* Modify `CMakeLists.txt` to include Google Test submodule, enable testing, add test executable, link Google Test libraries, and add test target.
* Update `.github/workflows/ci.yml` to run tests in both `build-linux` and `build-windows` jobs.
* Create `tests/test_main.cpp` with a basic unit test and test runner.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mpiispanen/platformer_prototype/issues/19?shareId=b15d1e27-d1d2-4c6d-b9e7-fdbcf4d91c58).