### PR TITLE
Add basic unit tests using Google Test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
     - name: Build
       run: cmake --build build
 
+    - name: Run unit tests
+      run: ctest --output-on-failure
+
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4
       with:
@@ -56,6 +59,9 @@ jobs:
 
     - name: Build
       run: cmake --build build
+
+    - name: Run unit tests
+      run: ctest --output-on-failure
 
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,3 +53,24 @@ if(ENABLE_CLANG_TIDY)
     COMMENT "Running clang-tidy"
   )
 endif()
+
+# Fetch Google Test
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  URL https://github.com/google/googletest/archive/refs/tags/release-1.11.0.zip
+)
+FetchContent_MakeAvailable(googletest)
+
+# Enable testing
+enable_testing()
+
+# Add test executable
+add_executable(tests tests/test_main.cpp)
+
+# Link Google Test to test target
+target_link_libraries(tests gtest_main)
+
+# Discover tests
+include(GoogleTest)
+gtest_discover_tests(tests)

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -1,0 +1,9 @@
+#include <gtest/gtest.h>
+
+TEST(SampleTest, Addition) {
+    EXPECT_EQ(1 + 1, 2);
+}
+
+TEST(SampleTest, Subtraction) {
+    EXPECT_EQ(2 - 1, 1);
+}


### PR DESCRIPTION
Fixes #19

Add basic unit tests using Google Test to the project.

* **CMakeLists.txt**
  - Fetch Google Test using `FetchContent`.
  - Enable testing with `enable_testing()`.
  - Add test executable `tests` and link it with Google Test.
  - Discover tests using `gtest_discover_tests`.

* **tests/test_main.cpp**
  - Include Google Test header.
  - Add sample test cases for addition and subtraction.

* **.github/workflows/ci.yml**
  - Add a step to run unit tests using `ctest` in `build-linux` job.
  - Add a step to run unit tests using `ctest` in `build-windows` job.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mpiispanen/platformer_prototype/issues/19?shareId=5c1e1e3d-ca85-4194-8806-a5a4080eda3b).