### PR TITLE
Enhance CI workflow for Clang-Tidy integration and reporting

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,4 @@
+Checks: '-*,modernize-*,readability-*'
+WarningsAsErrors: '*'
+HeaderFilterRegex: '^(src/.*|include/.*)$'
+FormatStyle: file

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,17 +83,16 @@ jobs:
 
     - name: Run clang-tidy and Generate Report
       run: cmake --build build --target run-clang-tidy
-      continue-on-error: true  # Allows subsequent steps to run even if this step fails
 
     - name: Upload Clang-Tidy Report
-      if: always()  # Ensures this step runs regardless of previous step success/failure
+      if: always()
       uses: actions/upload-artifact@v4
       with:
         name: clang-tidy-report
-        path: build/clang-tidy-fixes.yaml  # Path to the generated report
+        path: build/clang-tidy-fixes.yaml
 
     - name: Fail on Clang-Tidy Issues
-      if: failure()  # Only runs if the previous steps have failed
+      if: failure()
       run: |
         echo "Clang-Tidy detected issues. Failing the build."
         exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,16 +76,24 @@ jobs:
       uses: libsdl-org/setup-sdl@main
 
     - name: Set up clang-tidy
-      run: sudo apt-get install -y clang-tidy
+      run: sudo apt-get update && sudo apt-get install -y clang-tidy
 
     - name: Configure CMake with clang-tidy
       run: cmake -B build -S . -DENABLE_CLANG_TIDY=ON
 
-    - name: Run clang-tidy
+    - name: Run clang-tidy and Generate Report
       run: cmake --build build --target run-clang-tidy
+      continue-on-error: true  # Allows subsequent steps to run even if this step fails
 
-    - name: Upload static analysis results
+    - name: Upload Clang-Tidy Report
+      if: always()  # Ensures this step runs regardless of previous step success/failure
       uses: actions/upload-artifact@v4
       with:
-        name: static-analysis-results
-        path: build
+        name: clang-tidy-report
+        path: build/clang-tidy-fixes.yaml  # Path to the generated report
+
+    - name: Fail on Clang-Tidy Issues
+      if: failure()  # Only runs if the previous steps have failed
+      run: |
+        echo "Clang-Tidy detected issues. Failing the build."
+        exit 1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ if(ENABLE_CLANG_TIDY)
       --checks=${CLANG_TIDY_CHECKS}
       --warnings-as-errors=*  # Treat all warnings as errors
       --format-style=file      # Use .clang-format file for formatting
-      --export-fixes=clang-tidy-fixes.yaml  # Export fixes to a YAML file
+      --export-fixes=${CMAKE_BINARY_DIR}/clang-tidy-fixes.yaml  # Export fixes to a YAML file
       -- -Iexternal/cxxopts/include -Iexternal/box2d/include -Iexternal/sdl/include
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     COMMENT "Running clang-tidy on source files with report generation"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,18 +43,20 @@ option(ENABLE_CLANG_TIDY "Enable clang-tidy" OFF)
 
 # Enable Clang-Tidy if the option is ON
 if(ENABLE_CLANG_TIDY)
-  set(CMAKE_CXX_CLANG_TIDY "clang-tidy")
-endif()
-
-# Alternatively, create a custom target for Clang-Tidy
-if(ENABLE_CLANG_TIDY)
   find_program(CLANG_TIDY_EXE clang-tidy REQUIRED)
-  
-  set(CLANG_TIDY_CHECKS "*")
-  
+
+  # Define the Clang-Tidy checks you want to perform
+  set(CLANG_TIDY_CHECKS "-*,modernize-*,readability-*")  # Customize as needed
+
+  # Create a custom target for Clang-Tidy
   add_custom_target(run-clang-tidy
-    COMMAND ${CLANG_TIDY_EXE} ${SOURCE_FILES} -- -Iexternal/cxxopts/include -Iexternal/box2d/include -Iexternal/sdl/include
+    COMMAND ${CLANG_TIDY_EXE} ${SOURCE_FILES}
+      --checks=${CLANG_TIDY_CHECKS}
+      --warnings-as-errors=*  # Treat all warnings as errors
+      --format-style=file      # Use .clang-format file for formatting
+      --export-fixes=clang-tidy-fixes.yaml  # Export fixes to a YAML file
+      -- -Iexternal/cxxopts/include -Iexternal/box2d/include -Iexternal/sdl/include
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-    COMMENT "Running clang-tidy on source files"
+    COMMENT "Running clang-tidy on source files with report generation"
   )
 endif()


### PR DESCRIPTION
This pull request includes updates to the CI workflow and improvements to the Clang-Tidy configuration in the CMake build process. The changes aim to enhance the static analysis process and ensure better reporting and error handling.

### CI Workflow Enhancements:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL79-R99): Updated the Clang-Tidy setup to include `sudo apt-get update` before installation and added steps to generate and upload a Clang-Tidy report. The workflow now continues on error and fails the build if issues are detected.

### Clang-Tidy Configuration Improvements:

* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL45-R60): Modified the Clang-Tidy configuration to define specific checks, treat warnings as errors, use a formatting file, and export fixes to a YAML file. A custom target for Clang-Tidy was created to include these settings.